### PR TITLE
added define LS = ls

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -72,6 +72,7 @@ endif
 LD        = $(CXX)
 AR        = ar cru
 RANLIB    = ranlib
+LS        = ls
 
 ifeq ($(platform), unix)
    TARGET  := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
I needed to add that line to make it compile. Without it LS is not defined in scummvm/rules.mk line 87 and compilation fails with error 127. Maybe something changed upstream? Anyways, thank you for your work! Very happy about it!